### PR TITLE
Added API::Slip module.

### DIFF
--- a/lib/volabit/api.rb
+++ b/lib/volabit/api.rb
@@ -1,11 +1,13 @@
 
 require_relative 'api/rates'
 require_relative 'api/account'
+require_relative 'api/slip'
 
 module Volabit
   module API
     include Rates
     include Account
+    include Slip
 
     private
 

--- a/lib/volabit/api/slip.rb
+++ b/lib/volabit/api/slip.rb
@@ -1,0 +1,36 @@
+
+# Methods to manage slips in the user wallet.
+module Slip
+  # Creates a slip you can use to load your wallet.
+  def create_slip(currency:, amount:, type:)
+    post_to_resource 'api/v1/users/me/slips', {
+      currency: currency,
+      amount: amount,
+      type: type
+    }
+  end
+
+  # Gets the information of a specific slip.
+  def get_slip_data(id:)
+    get_resource "api/v1/users/me/slips/#{id}"
+  end
+
+  # Deletes a specific slip.
+  def delete_slip(id:)
+    delete_resource "api/v1/users/me/slips/#{id}"
+  end
+
+  # Informs of a receipt used to load a wallet's slip.
+  def report_receipt(id:, amount:, affiliation:, authorization:)
+    post_to_resource "api/v1/users/me/slips/#{id}/report", {
+      amount: amount,
+      affiliation_number: affiliation,
+      authorization_number: authorization
+    }
+  end
+
+  # Lists the available methods to load a slip.
+  def get_load_methods
+    get_resource 'api/v1/users/me/slips/methods'
+  end
+end


### PR DESCRIPTION
Methods to manage slips.
- The `report_receipt` method could not be fully checked due a bug in the test server.
